### PR TITLE
백준-hrso/회문_17609

### DIFF
--- a/BOJ/hrso/회문_17609.java
+++ b/BOJ/hrso/회문_17609.java
@@ -1,0 +1,35 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main{
+    static String str;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < T; i++) {
+            str = br.readLine();
+            System.out.println(palindrome(0, str.length()-1, 0));
+        }
+    }
+
+    public static int palindrome (int lt, int rt, int del) {
+        if (del == 2) return del;
+
+        while (lt < rt){
+            if (str.charAt(lt) == str.charAt(rt)){
+                lt ++;
+                rt --;
+            } else {
+                int ltSliding = palindrome(lt+1,rt,del+1);
+                int rtSliding = palindrome(lt,rt-1,del+1);
+                return Math.min(ltSliding,rtSliding);
+            }
+
+        }
+
+        return del;
+    }
+}
+


### PR DESCRIPTION
# 문제 
회문,유사회문, 둘다 아닌 경우를 판별하여 0,1,2로 출력해야 한다.

# 발상
팰린더룸이니까 투포인터 알고리즘 쓰겠구나, 
for문 으로 문자열 하나씩 hashmap 자료구조로 저장하고, 문자열 reverse로 다시 for문 돌려서 hashmap이랑 비교해서 cnt
0,1,2 출력하면 되려나.? 

# 코드 구현 중 발생했던 문제점
재귀함수로 결과값 받는 26,27 라인에서 원하는 값이 안나옴.
디버깅해도 못찾아서 풀이 한번 보고 난후 33번 라인 return값을 잘못주고있었음 


# 해결
우선 T 번 만큼 순회하면서 입력받은 문자열을 static 변수로 할당하고, palindrome 함수에 투포인터 알고리즘을 하기위한
left,right 변수값과 유사회문인지 일반 문자열인지를 판단하기위한 del 변수를 파라미터로 받아서 
left는 문자열 첫번째 인덱스 부터, right는 문자열 길이-1 인덱스 부터 비교하면서 좁혀 나가는 방식으로 해결. 
그냥 회문=팰린더룸을 묻는 문제였다면 투포인터 알고리즘으로 끝났을거같고 유사회문,일반문자열까지 해결하기위해 재귀함수가 쓰임 

# 풀이과정
20분 고민 -> 풀이봄 -> 투포인터,재귀함수 포인트 이해하고 30분 코드-> 답이 이상하게나옴 -> 재풀이 
