### PR TITLE
[BOJ] 회문인수, 사탕게임,ACM호텔, 판화

### DIFF
--- a/BOJ/sunro/simulation/ACM_호텔_10250.java
+++ b/BOJ/sunro/simulation/ACM_호텔_10250.java
@@ -1,0 +1,20 @@
+package Array.gold.simulation;
+
+import java.util.Scanner;
+
+public class ACM_호텔_10250 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+        while(n-->0) {
+            int H = sc.nextInt();
+            int W = sc.nextInt();
+            int request = sc.nextInt();
+
+            int XX = ((request-1)/H)+1;
+            int YY = ((request-1)%H)+1;
+
+            System.out.printf("%d%02d",YY,XX);
+        }
+    }
+}

--- a/BOJ/sunro/simulation/사탕_게임_3085.java
+++ b/BOJ/sunro/simulation/사탕_게임_3085.java
@@ -1,0 +1,91 @@
+package Array.gold.simulation;
+
+import java.util.Scanner;
+
+public class 사탕_게임_3085 {
+
+    //1.가능한 모든 쌍의 캔디를 서로 교환
+    //2. 교환 상태에서 가장 긴 행/열을 찾음
+    //3. 교환 사탕을 원복
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+        char[][] map = new char[n][n];
+        for (int i = 0; i < n; i++) {
+            map[i] = sc.next().toCharArray();
+        }
+
+        int ans = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                ans = findMaxInRow(j, n, map, i, ans);
+                ans = findMaxInCol(i, n, map, j, ans);
+            }
+            if(ans==n) break;
+        }
+        System.out.println(ans);
+    }
+
+    private static int findMaxInCol(int i, int n, char[][] map, int j, int ans) {
+        if (i + 1 < n && map[i][j] != map[i + 1][j]) {
+            swap(map, i, j, i + 1, j);
+            ans = Math.max(ans, Math.max(findMaxCol(map), findMaxRow(map)));
+            swap(map, i, j, i + 1, j);
+        }
+        return ans;
+    }
+
+    private static int findMaxInRow(int j, int n, char[][] map, int i, int ans) {
+        if (j + 1 < n && map[i][j] != map[i][j + 1]) {
+            swap(map, i, j, i, j + 1);
+            ans = Math.max(ans, Math.max(findMaxCol(map), findMaxRow(map)));
+            swap(map, i, j, i, j + 1);
+        }
+        return ans;
+    }
+
+    public static int findMaxRow(char[][] map) {
+        int N = map.length;
+        int maxRow = 0;
+        for (char[] chars : map) {
+            int len = 1;
+            for (int c = 1; c < N; c++) {
+                if (chars[c] == chars[c - 1]) {
+                    len++;
+                } else {
+                    maxRow = Math.max(maxRow, len);
+                    len = 1;
+                }
+            }
+            maxRow = Math.max(maxRow, len); //len값 초기화되기전에 업데이트
+        }
+        return maxRow;
+    }
+
+    public static int findMaxCol(char[][] map) {
+        int N = map.length;
+        int maxrow = 0;
+        for (int c = 0; c < N; c++) {
+            int len = 1;
+            for (int r = 1; r < N; r++) {
+                if (map[r][c] == map[r-1][c]) {
+                    len++;
+                } else {
+                    maxrow = Math.max(maxrow, len);
+                    len = 1;
+                }
+            }
+            maxrow = Math.max(maxrow, len);
+        }
+        return maxrow;
+    }
+
+
+    public static void swap(char[][] map, int r1, int c1, int r2, int c2) {
+        char tmp = map[r1][c1];
+        map[r1][c1] = map[r2][c2];
+        map[r2][c2] = tmp;
+    }
+
+
+}

--- a/BOJ/sunro/simulation/판화_1730.java
+++ b/BOJ/sunro/simulation/판화_1730.java
@@ -1,0 +1,90 @@
+package Array.gold.simulation;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class 판화_1730 {
+    static int N;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        // 입력 받기
+        N = Integer.parseInt(br.readLine());
+        String order = br.readLine();
+
+        Robot robot = new Robot(N); // N을 전달하여 Robot 생성
+        for (int i = 0; i < order.length(); i++) {
+            robot.move(order.charAt(i), robot.curPos);
+        }
+        robot.print(robot.visitedRow, robot.visitedCol);
+    }
+
+    static class Robot {
+        int[] curPos = new int[]{0, 0};
+        boolean[][] visitedRow;
+        boolean[][] visitedCol;
+
+        public Robot(int n) {
+            this.visitedRow = new boolean[n][n];
+            this.visitedCol = new boolean[n][n];
+        }
+
+        public void move(char direction, int[] curPos) {
+            if (direction == 'L') {
+                if (curPos[1] - 1 < 0) {
+                    return;
+                } else {
+                    visitedRow[curPos[0]][curPos[1]] = true;
+                    curPos[1]--;
+                    visitedRow[curPos[0]][curPos[1]] = true;
+                }
+            }
+            if (direction == 'R') {
+                if (curPos[1] + 1 >= N) {
+                    return;
+                } else {
+                    visitedRow[curPos[0]][curPos[1]] = true;
+                    curPos[1]++;
+                    visitedRow[curPos[0]][curPos[1]] = true;
+                }
+            }
+            if (direction == 'U') {
+                if (curPos[0] - 1 < 0) {
+                    return;
+                } else {
+                    visitedCol[curPos[0]][curPos[1]] = true;
+                    curPos[0]--;
+                    visitedCol[curPos[0]][curPos[1]] = true;
+                }
+            }
+            if (direction == 'D') {
+                if (curPos[0] + 1 >= N) {
+                    return;
+                } else {
+                    visitedCol[curPos[0]][curPos[1]] = true;
+                    curPos[0]++;
+                    visitedCol[curPos[0]][curPos[1]] = true;
+                }
+            }
+        }
+
+        public void print(boolean[][] row, boolean[][] cul) {
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    if (row[i][j] && cul[i][j]) {
+                        System.out.print('+');
+                    } else if (row[i][j] && !cul[i][j]) {
+                        System.out.print('-');
+                    } else if (cul[i][j] && !row[i][j]) {
+                        System.out.print('|');
+                    } else {
+                        System.out.print('.');
+                    }
+                }
+                System.out.println();
+            }
+        }
+    }
+}

--- a/BOJ/sunro/simulation/회문인_수_11068.java
+++ b/BOJ/sunro/simulation/회문인_수_11068.java
@@ -1,0 +1,51 @@
+package Array.gold.simulation;
+
+import java.util.Scanner;
+
+public class 회문인_수_11068 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int N = sc.nextInt();
+        while (N-- > 0) {
+            int M = sc.nextInt();
+            if (isRotateNum(String.valueOf(M))) {
+                System.out.println(1);
+            } else if (isRotateNumUsingDigit(M)) {
+                System.out.println(1);
+            }else{
+                System.out.println(0);
+            }
+        }
+    }
+
+    private static boolean isRotateNumUsingDigit(int m) {
+        for (int i = 2; i <= 64; i++) {
+            String result = convertTo(m, i);
+            if (isRotateNum(result)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String convertTo(int m, int i) {
+        StringBuilder sb = new StringBuilder();
+        while (m > 0) {
+            int digit = m % i; //255 -> 15 // 15-> 15
+            if (digit >= 10) {
+                int pos = digit-10;
+                sb.append((char) ('A' + pos)); // 'A'+5 -> F // 'A' + 5 -> F
+            } else {
+                sb.append(digit);
+            }
+            m /= i; // 15 //0
+        }
+        return sb.reverse().toString();
+    }
+
+    private static boolean isRotateNum(String m) {
+        StringBuilder target = new StringBuilder(m);
+        return m.equals(target.reverse().toString());
+    }
+
+}


### PR DESCRIPTION
# 문제 
## 회문인 수
## 사탕 게임
## ACM호텔
## 판화

# 발상
## 회문인수
-  각 진법 계산후 나머지10이상은 알파벳으로 치환

## 사탕게임
-  각 열과행을 교환후 최대 중복개수를 파악

## ACM 호텔
- 층과 호수를 나누기와 나머지로 계산

## 판화
Robot 클래스를 만들어 이동 및 기록



# 코드 구현 중 발생했던 문제점
## 사탕 게임
- 비교 이후 원위치를 안시켜줘서 정답이 안나옴..

## ACM 호텔
- 최상층과 최하층 계산이 중복되어 원하는 답이 나오지 않음

## 판화
- Scanner로 했더니 96%에서 계속 NoSuchElement가 뜸..


# 해결
## 사탕 게임
- 비교 후 원복

## ACM 호텔
- 연산하기 전에 -1 감소시킨후 +1 연산하기

## 판화
-  bufferedReader로 풀었던 해결됨


# 규칙발견(필요시 적기)
## 회문인 수
- 회문인 판단은 가운데 글자 기준으로 뒤집으면 비교 가능

# 메모리 및 속도

| **메모리**      | **속도**       |
|---------------|------------------|
|    16392  kb|  140 mb |
|    13140  kb|  140 mb |
|    10480  kb|  128 mb |
|    11480  kb|  64 mb |

